### PR TITLE
use https and URI.open

### DIFF
--- a/lib/paysera/response.rb
+++ b/lib/paysera/response.rb
@@ -63,7 +63,7 @@ module Paysera
     end
 
     def get_public_key
-      OpenSSL::X509::Certificate.new(open(PAYSERA_PUBLIC_KEY).read).public_key
+      OpenSSL::X509::Certificate.new(URI.open(PAYSERA_PUBLIC_KEY).read).public_key
     end
 
     def safely_decode_string(string)

--- a/lib/paysera/response.rb
+++ b/lib/paysera/response.rb
@@ -6,7 +6,7 @@ require 'base64'
 
 module Paysera
   class Response
-    PAYSERA_PUBLIC_KEY = 'http://www.paysera.com/download/public.key'
+    PAYSERA_PUBLIC_KEY = 'https://www.paysera.com/download/public.key'
 
     def initialize(query, projectid: nil, sign_password: nil)
       raise send_error("'data' parameter was not found") if query[:data].nil?

--- a/lib/paysera/version.rb
+++ b/lib/paysera/version.rb
@@ -1,3 +1,3 @@
 module Paysera
-  VERSION = '0.0.4'
+  VERSION = '0.0.5'
 end


### PR DESCRIPTION
Hi,

thanks for the gem!

Lets download public key via https :)

calling URI.open via Kernel#open was deprecated some time ago
and it doesn't work on ruby 3 for me so I changed it call URI.open directly

here was my output, this pr fixes it.
```
artis@Artiss-MacBook-Pro paysera % irb          
3.0.0 :001'> require 'open-uri'
 => true 
3.0.0 :002 > open('https://www.paysera.com/download/public.key')
Traceback (most recent call last):
        6: from /Users/artis/.rvm/rubies/ruby-3.0.0/bin/irb:23:in `<main>'
        5: from /Users/artis/.rvm/rubies/ruby-3.0.0/bin/irb:23:in `load'
        4: from /Users/artis/.rvm/rubies/ruby-3.0.0/lib/ruby/gems/3.0.0/gems/irb-1.3.0/exe/irb:11:in `<top (required)>'
        3: from (irb):2:in `<main>'
        2: from (irb):2:in `open'
        1: from (irb):2:in `initialize'
Errno::ENOENT (No such file or directory @ rb_sysopen - https://www.paysera.com/download/public.key)
3.0.0 :003 > exit
artis@Artiss-MacBook-Pro paysera % rvm use 2.7.0
Using /Users/artis/.rvm/gems/ruby-2.7.0
artis@Artiss-MacBook-Pro paysera % irb
2.7.0 :001 > require 'open-uri'
 => true 
2.7.0 :002 > open('https://www.paysera.com/download/public.key')
(irb):2: warning: calling URI.open via Kernel#open is deprecated, call URI.open directly or use URI#open
 => #<StringIO:0x00007fcc79170de8 @base_uri=#<URI::HTTPS https://www.paysera.com/download/public.key>, @meta={"date"=>"Sun, 18 Apr 2021 09:04:52 GMT", "content-type"=>"application/octet-stream", "content-length"=>"1461", "connection"=>"keep-alive", "set-cookie"=>"__cfduid=dee2435db8fa3333dfe0425a2fd21a1651618736692; expires=Tue, 18-May-21 09:04:52 GMT; path=/; domain=.paysera.com; HttpOnly; SameSite=Lax", "last-modified"=>"Fri, 16 Apr 2021 13:42:53 GMT", "etag"=>"\"6079945d-5b5\"", "x-backend"=>"mokejimai-web-hw4", "accept-ranges"=>"bytes", "cache-control"=>"public, max-age=43200", "cf-cache-status"=>"DYNAMIC", "cf-request-id"=>"0985d2d5290000ffd497a57000000001", "expect-ct"=>"max-age=604800, report-uri=\"https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct\"", "x-content-type-options"=>"nosniff", "server"=>"cloudflare", "cf-ray"=>"641cba6849e3ffd4-WAW"}, @metas={"date"=>["Sun, 18 Apr 2021 09:04:52 GMT"], "content-type"=>["application/octet-stream"], "content-length"=>["1461"], "connection"=>["keep-alive"], "set-cookie"=>["__cfduid=dee2435db8fa3333dfe0425a2fd21a1651618736692; expires=Tue, 18-May-21 09:04:52 GMT; path=/; domain=.paysera.com; HttpOnly; SameSite=Lax"], "last-modified"=>["Fri, 16 Apr 2021 13:42:53 GMT"], "etag"=>["\"6079945d-5b5\""], "x-backend"=>["mokejimai-web-hw4"], "accept-ranges"=>["bytes"], "cache-control"=>["public, max-age=43200"], "cf-cache-status"=>["DYNAMIC"], "cf-request-id"=>["0985d2d5290000ffd497a57000000001"], "expect-ct"=>["max-age=604800, report-uri=\"https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct\""], "x-content-type-options"=>["nosniff"], "server"=>["cloudflare"], "cf-ray"=>["641cba6849e3ffd4-WAW"]}, @status=["200", "OK"]> 
2.7.0 :003 > 
```



